### PR TITLE
Eliminate redundant simulations

### DIFF
--- a/initialize.cpp
+++ b/initialize.cpp
@@ -29,7 +29,7 @@ void assignTeamNames(){
 	}
 }
 
-void readSchedule(){
+void readSchedule(int& weeksPlayed){
 	ifstream file; // input file
 	file.open("seasonSchedule.txt");
 	if(!file) // failed to open input file?
@@ -38,6 +38,7 @@ void readSchedule(){
 
 	int week, homeScore, awayScore;
 	bool scheduled, played;
+	bool allGamesPlayed = true; // becomes false if any scheduled game not yet played
 	string homeTeam, awayTeam;
 
 	for(int x = 0; x < NUMBER_OF_WEEKS; x++){ // for each week in season
@@ -78,9 +79,13 @@ void readSchedule(){
 					league[homeTeamID].add_tieAgainst(awayTeamID);
 				}
 			}
+			else if(scheduled){ // game not played, but game is scheduled?
+				allGamesPlayed = false;
+			}
 		} // end read game from schedule
+	if(allGamesPlayed)
+		weeksPlayed++;
 	} // end read week from schedule
-
 	file.close();
 }
 

--- a/initialize.h
+++ b/initialize.h
@@ -13,7 +13,6 @@
 
 using namespace std;
 
-
 /*	void assignTeamNames()
  * 	Purpose: sets name for all instances of Team
  * 	Preconditions:
@@ -31,13 +30,14 @@ void assignTeamNames();
  * 	<1> Input file properly formatted
  * 	<2> seasonSchedule 2-D array initialized
  * 	<3> league array initialized
- * Parameters: n/a
+ * Parameters:
+ * 	<1> int - number of weeks fully played in the season to date
  * No return
- * Side effect:
+ * Side effects:
  * 	<1> seasonSchedule array filled with scheduled game details
  * 	<2> league array updated with information from games previously played
  */
-void readSchedule();
+void readSchedule(int& weeksPlayed);
 
 /* int teamNameToID()
  * Purpose: takes team nickname (string), returns teamID (int)

--- a/main.cpp
+++ b/main.cpp
@@ -13,8 +13,7 @@
 
 using namespace std;
 
-void runSimulation(){
-
+void runSimulation(int& weeksPlayed){
 
 	cout << "Beginning simulation . . ." << endl;
 
@@ -23,13 +22,13 @@ void runSimulation(){
 
 		copyLeague(); // copy league array to new array
 
-		simulateSeason(); // simulate all unplayed games in season
+		simulateSeason(weeksPlayed); // simulate all unplayed games in season
 
 		crunchSeasonResults();// record results
 
 	}
 
-	cout << "100%! Simulation completed, printing report . . ." << endl;
+	cout << "Simulation completed, printing report . . ." << endl;
 
 	// print summary of simulation
 	print_report();
@@ -38,11 +37,14 @@ void runSimulation(){
 }
 
 int main(){
+	int weeksPlayed = 0;
+
+
 	cout << "CFL Playoff Calculator" << endl;
 	srand(time(0)); // set random number seed
 	assignTeamNames(); // set names for all teams in league array
 	cout << "Reading schedule . . . " << endl;
-	readSchedule(); // read all game details into schedule array, update team statistics
+	readSchedule(weeksPlayed); // read all game details into schedule array, update team statistics
 
 	// run main menu
 	int selection = -1;
@@ -54,7 +56,7 @@ int main(){
 		cout << "Please enter a selection: ";
 		cin >> selection;
 		if(selection == 1)
-			runSimulation();
+			runSimulation(weeksPlayed);
 		else if(selection == 9)
 			break;
 		else

--- a/report.txt
+++ b/report.txt
@@ -7,40 +7,40 @@ TEAM RESULTS
 Saskatchewan Roughriders
 Division: west
 
-1st place finishes:           3251324   0.325     
-2nd place finishes:           3326264   0.333     
-3rd place (made playoffs):    2349449   0.235     
-Crossovers:                   1072963   0.107     
+1st place finishes:           3253122   0.325     
+2nd place finishes:           3326022   0.333     
+3rd place (made playoffs):    2348358   0.235     
+Crossovers:                   1072498   0.107     
 Times missed playoffs:        0         0.000     
 % chance of making the playoffs: 1.000
 
 Edmonton Eskimos
 Division: west
 
-1st place finishes:           5913      0.001     
-2nd place finishes:           276971    0.028     
-3rd place (made playoffs):    1301482   0.130     
-Crossovers:                   8330484   0.833     
-Times missed playoffs:        85150     0.009     
+1st place finishes:           6029      0.001     
+2nd place finishes:           277599    0.028     
+3rd place (made playoffs):    1300717   0.130     
+Crossovers:                   8330231   0.833     
+Times missed playoffs:        85424     0.009     
 % chance of making the playoffs: 0.991
 
 Calgary Stampeders
 Division: west
 
-1st place finishes:           3853360   0.385     
-2nd place finishes:           3121151   0.312     
-3rd place (made playoffs):    2848794   0.285     
-Crossovers:                   176695    0.018     
+1st place finishes:           3851918   0.385     
+2nd place finishes:           3119595   0.312     
+3rd place (made playoffs):    2852143   0.285     
+Crossovers:                   176344    0.018     
 Times missed playoffs:        0         0.000     
 % chance of making the playoffs: 1.000
 
 Winnipeg Blue Bombers
 Division: west
 
-1st place finishes:           2889403   0.289     
-2nd place finishes:           3275614   0.328     
-3rd place (made playoffs):    3500275   0.350     
-Crossovers:                   334708    0.033     
+1st place finishes:           2888931   0.289     
+2nd place finishes:           3276784   0.328     
+3rd place (made playoffs):    3498782   0.350     
+Crossovers:                   335503    0.034     
 Times missed playoffs:        0         0.000     
 % chance of making the playoffs: 1.000
 
@@ -50,45 +50,45 @@ Division: west
 1st place finishes:           0         0.000     
 2nd place finishes:           0         0.000     
 3rd place (made playoffs):    0         0.000     
-Crossovers:                   83264     0.008     
-Times missed playoffs:        9916736   0.992     
+Crossovers:                   83599     0.008     
+Times missed playoffs:        9916401   0.992     
 % chance of making the playoffs: 0.008
 
 Ottawa REDBLACKS
 Division: east
 
 1st place finishes:           0         0.000     
-2nd place finishes:           34425     0.003     
+2nd place finishes:           34794     0.003     
 3rd place (made playoffs):    0         0.000     
 Crossovers:                   0         0.000     
-Times missed playoffs:        9965575   0.997     
+Times missed playoffs:        9965206   0.997     
 % chance of making the playoffs: 0.003
 
 Toronto Argonauts
 Division: east
 
 1st place finishes:           0         0.000     
-2nd place finishes:           1672      0.000     
+2nd place finishes:           1600      0.000     
 3rd place (made playoffs):    0         0.000     
 Crossovers:                   0         0.000     
-Times missed playoffs:        9998328   1.000     
+Times missed playoffs:        9998400   1.000     
 % chance of making the playoffs: 0.000
 
 Montreal Alouettes
 Division: east
 
-1st place finishes:           285223    0.029     
-2nd place finishes:           9678680   0.968     
-3rd place (made playoffs):    1886      0.000     
+1st place finishes:           286015    0.029     
+2nd place finishes:           9677591   0.968     
+3rd place (made playoffs):    1825      0.000     
 Crossovers:                   0         0.000     
-Times missed playoffs:        34211     0.003     
+Times missed playoffs:        34569     0.003     
 % chance of making the playoffs: 0.997
 
 Hamilton Tiger Cats
 Division: east
 
-1st place finishes:           9714777   0.971     
-2nd place finishes:           285223    0.029     
+1st place finishes:           9713985   0.971     
+2nd place finishes:           286015    0.029     
 3rd place (made playoffs):    0         0.000     
 Crossovers:                   0         0.000     
 Times missed playoffs:        0         0.000     

--- a/simulation.cpp
+++ b/simulation.cpp
@@ -30,12 +30,12 @@ void copyLeague(){
 	}
 }
 
-void simulateSeason(){
+void simulateSeason(int lastWeekPlayed){
 	// set all teams "ranked" status to false
 	for(int x = 0; x < NUMBER_OF_TEAMS; x++){
 		sim_league[x].set_ranked(false);
 	}
-	for(int x = 0; x < NUMBER_OF_WEEKS; x++){ // for each week of season
+	for(int x = lastWeekPlayed - 1; x < NUMBER_OF_WEEKS; x++){ // for each week of season
 		for(int y = 0; y < MAX_GAMES_PER_WEEK; y++){ // for each game in week
 			if(sim_seasonSchedule[x][y].is_scheduled() // game scheduled?
 					and !sim_seasonSchedule[x][y].was_played()){ // game not yet played?

--- a/simulation.h
+++ b/simulation.h
@@ -26,7 +26,16 @@ using namespace std;
 
 void copySchedule(); // copies 2-D season scheduled array so simulation will not modify original data
 void copyLeague(); // copies league array so simulation will not modify original data
-void simulateSeason(); // simulates all unplayed games in season
+/* void simulateSeason
+ *
+ * Purpose: Simulates all unplayed games in season
+ * Preconditions:
+ * 	<1> league[] array must be copied to sim_league[] prior to function call
+ * 	<2> seasonSchedule[][] array must be copied to sim_seasonSchedule[][] prior to function call
+ * Parameters:
+ * 	<1> int - the number of the week of the season that was most recently fully played
+ */
+void simulateSeason(int lastWeekPlayed);
 /* void crunchSeasonResults()
  * Purpose: determines final season rankings for a simulated season
  * Preconditions:


### PR DESCRIPTION
Each season simulation now begins on the first week that has not been fully played - previously, the season simulation checked every space in the schedule grid to see if it had been played, and simulated the game if an unplayed game was scheduled. Runtime has decreased slightly as a result.